### PR TITLE
remove validation for log_level

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,12 +62,7 @@ export OKTETO_DISABLE_SPINNER=1
 
 log_level=$7
 if [ ! -z "$log_level" ]; then
-  if [ "$log_level" = "debug" ] || [ "$log_level" = "info" ] || [ "$log_level" = "warn" ] || [ "$log_level" = "error" ] ; then
-    log_level="--log-level ${log_level}"
-  else
-    echo "unsupported log-level ${log_level}, supported options are: debug, info, warn, error"
-    exit 1
-  fi
+  log_level="--log-level ${log_level}"
 fi
 
 # https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging


### PR DESCRIPTION
Validation not needed. Default `warn` is used by CLI when value is not recognized by it.

Commit will be cherry picked to v2 when merged to main.